### PR TITLE
Fix games filtering and tighten tests

### DIFF
--- a/REVIEW_TASKS.md
+++ b/REVIEW_TASKS.md
@@ -1,0 +1,21 @@
+# Revue du code : tâches proposées
+
+## 1. Corriger une coquille typographique
+- **Fichier** : `src/docs/ARCHITECTURE.md`
+- **Problème** : le document contient plusieurs mentions de « joueurs(nexiste pas pour le moment) » sans espace ni apostrophe, ce qui nuit à la lisibilité.
+- **Action proposée** : insérer l'espace et l'apostrophe manquants pour obtenir « joueurs (n'existe pas pour le moment) » aux lignes concernées.
+
+## 2. Corriger un bug fonctionnel
+- **Fichier** : `src/components/GamesPage.tsx`
+- **Problème** : la propriété `games` utilisée par `GamesPageView` provient toujours de `gamesProp`. Les résultats filtrés et triés calculés par le hook `useGamesPage` (valeur `games`) ne sont jamais transmis à la vue, ce qui rend la barre de recherche et les filtres inopérants.
+- **Action proposée** : récupérer la valeur `games` renvoyée par `useGamesPage` et la passer à `GamesPageView` à la place de `gamesProp`.
+
+## 3. Corriger un commentaire / anomalie de documentation
+- **Fichier** : `src/views/DashboardView.tsx`
+- **Problème** : la ligne de commentaire « Annulation de l'import Button » (ligne 2) est obsolète et ne décrit aucune logique actuelle, ce qui ajoute de la confusion.
+- **Action proposée** : supprimer ou réécrire ce commentaire pour refléter l'état réel du fichier.
+
+## 4. Améliorer un test
+- **Fichier** : `src/__tests__/hooks/useGamesPage.test.ts`
+- **Problème** : les tests vérifient la mise à jour de `searchQuery` mais n'assertent pas que la liste `games` renvoyée par le hook est réellement filtrée en fonction de cette recherche, laissant le bug décrit ci-dessus passer inaperçu.
+- **Action proposée** : ajouter un test qui vérifie que `result.current.games` ne contient que les jeux correspondant au terme de recherche, afin de détecter la régression actuelle et d'empêcher son retour.

--- a/src/__tests__/hooks/useGamesPage.test.ts
+++ b/src/__tests__/hooks/useGamesPage.test.ts
@@ -103,9 +103,8 @@ describe('useGamesPage', () => {
       result.current.setSearchQuery('wingspan');
     });
 
-    // Les jeux filtrés devraient être accessibles via result.current.games
-    // (ceci dépend de l'implémentation exacte du hook)
-    expect(result.current.searchQuery).toBe('wingspan');
+    expect(result.current.games).toHaveLength(1);
+    expect(result.current.games[0].name).toBe('Wingspan');
   });
 
   it('should reset form data', () => {

--- a/src/components/GamesPage.tsx
+++ b/src/components/GamesPage.tsx
@@ -54,6 +54,7 @@ export default function GamesPage({
   };
 
   const {
+    games: filteredGames,
     totalGames,
     averageRating,
     formData,
@@ -94,31 +95,31 @@ export default function GamesPage({
 
   return (
     <GamesPageView
-        games={gamesProp}
-        currentView={currentViewProp || 'games'}
-        totalGames={totalGames}
-        averageRating={averageRating}
-        formData={formData}
-        editingGame={editingGame}
-        isAddDialogOpen={isAddDialogOpen}
-        isEditDialogOpen={isEditDialogOpen}
-        isBGGSearchOpen={isBGGSearchOpen}
-        expandedGame={expandedGame}
-        searchQuery={searchQuery}
-        onNavigation={onNavigationProp}
-        onSearchChange={setSearchQuery}
-        onAddDialogToggle={onAddDialogToggle}
-        onFormDataChange={handleFormDataChange}
-        onBGGGameSelect={handleBGGGameSelect}
-        onAddGame={handleAddGame}
-        onResetForm={resetForm}
-        onEditGame={handleEditGame}
-        onUpdateGame={handleUpdateGame}
-        onDeleteGame={handleDeleteGame}
-        setBGGSearchOpen={setIsBGGSearchOpen}
-        setExpandedGame={setExpandedGame}
-        setEditDialogOpen={handleEditDialogOpen}
-  darkMode={!!darkMode}
-      />
+      games={filteredGames}
+      currentView={currentViewProp || 'games'}
+      totalGames={totalGames}
+      averageRating={averageRating}
+      formData={formData}
+      editingGame={editingGame}
+      isAddDialogOpen={isAddDialogOpen}
+      isEditDialogOpen={isEditDialogOpen}
+      isBGGSearchOpen={isBGGSearchOpen}
+      expandedGame={expandedGame}
+      searchQuery={searchQuery}
+      onNavigation={onNavigationProp}
+      onSearchChange={setSearchQuery}
+      onAddDialogToggle={onAddDialogToggle}
+      onFormDataChange={handleFormDataChange}
+      onBGGGameSelect={handleBGGGameSelect}
+      onAddGame={handleAddGame}
+      onResetForm={resetForm}
+      onEditGame={handleEditGame}
+      onUpdateGame={handleUpdateGame}
+      onDeleteGame={handleDeleteGame}
+      setBGGSearchOpen={setIsBGGSearchOpen}
+      setExpandedGame={setExpandedGame}
+      setEditDialogOpen={handleEditDialogOpen}
+      darkMode={!!darkMode}
+    />
   );
 }

--- a/src/docs/ARCHITECTURE.md
+++ b/src/docs/ARCHITECTURE.md
@@ -11,13 +11,13 @@ src/
 ├── components/           # Composants React principaux
 │   ├── dialogs/         # Boîtes de dialogue réutilisables
 │   ├── games/           # Composants spécifiques aux jeux
-│   ├── players/         # Composants spécifiques aux joueurs(nexiste pas pour le moment)
+│   ├── players/         # Composants spécifiques aux joueurs (n'existe pas pour le moment)
 │   └── ui/              # Composants UI de base (shadcn)
 ├── *.tsx                #
 ├── docs/                # Documentation frontend
 ├── hooks/               # Hooks React personnalisés
 │   ├── games/           # Hooks spécifiques aux jeux
-│   ├── players/         # Hooks spécifiques aux joueurs(nexiste pas pour le moment)
+│   ├── players/         # Hooks spécifiques aux joueurs (n'existe pas pour le moment)
 │   └── *.tsx                #
 ├── lib/                 # Utilitaires
 ├── services/            # Services pour les appels API BGG
@@ -26,7 +26,7 @@ src/
 ├── utils/               # Test BGG
 ├── views/               # Composants de vue (présentation)
 │   ├── games/           # Vues spécifiques aux jeux
-│   ├── players/         # Vues spécifiques aux joueurs (nexiste pas pour le moment)
+│   ├── players/         # Vues spécifiques aux joueurs (n'existe pas pour le moment)
 │   └── *.tsx            #
 ```
 

--- a/src/views/DashboardView.tsx
+++ b/src/views/DashboardView.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-// Annulation de l'import Button
 import {
   Users,
   GameController,


### PR DESCRIPTION
## Summary
- correct the French player section typo in the architecture guide
- wire the filtered game list from the useGamesPage hook into GamesPageView and clean up an obsolete dashboard comment
- extend the useGamesPage hook test to verify the filtered results

## Testing
- npm run test -- useGamesPage

------
https://chatgpt.com/codex/tasks/task_e_68dc30e5b29c832d8679dacfecf19d64