### PR TITLE
feat(bgg): lazy thumbnail cache via bgg_catalog_language

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # 🗺️ Roadmap — Board Game Dashboard
 
-**📈 Status**: 343 tests (209 backend + 134 frontend) · Phase 3 in progress
+**📈 Status**: 346 tests (212 backend + 134 frontend) · Phase 3 in progress
 
 ---
 
@@ -17,8 +17,8 @@
 - **`has_expansion`/`has_characters` not recalculated on add/delete**: `addExpansion()` and `deleteExpansion()` do not update the flag on the parent game. Low impact (`getById()` always loads expansions), but `getAll()` may return `expansions: []` incorrectly.
 - **Labels EditGameDialog**: DB enum values (`Beginner`, `Intermediate`, `competitive`…) display in English in edit forms. To fix via centralized maps `DIFFICULTY_LABELS`, `GAME_TYPE_LABELS` consumed by `t()`.
 - **📅 BGG year filter**: client-side filtering on geekdo results (no `yearpublished` server parameter). Low priority.
-- **🗄️ Local BGG index — search to wire up**: infrastructure delivered (PR #59). Remaining: connect `searchGames()` to `bgg_catalog` (FTS5 to consider for 175k entries). Once wired: add year field + "include expansions" toggle in `BGGSearch`.
-- **🖼️ BGG thumbnails not persisted**: up to 15 geekdo calls repeated on every search. Solution: `bgg_thumbnails (bgg_id PK, thumbnail_url, fetched_at)` table independent of the CSV import cycle.
+- **🗄️ Local BGG index — search wired** ✅ (PR #79): `search()` queries `bgg_catalog` + `bgg_catalog_language` (name_en/fr/es), ordered by rank. Remaining: add year field + "include expansions" toggle in `BGGSearch`.
+- **🖼️ BGG thumbnails — lazy cache** ✅ (PR #93): thumbnail persisted in `bgg_catalog_language` on first `getGameDetails` call. Subsequent searches return thumbnail from local DB — no repeated geekdo calls.
 - **🕒 `name_updated_at` in `bgg_catalog_language`**: timestamp of last `name_en` update — useful for detecting BGG renames and invalidating translations. To consider during the "local catalog" sprint.
 - **🔽 BGG search — autocomplete**: replace the text field with an autocomplete component (free input + filter on en/fr/es names). Selection must transmit the `bgg_id`, not the name — avoids homonym issues.
 
@@ -76,7 +76,7 @@ Functional dark/light theme (to migrate from prop-drilling → Tailwind `dark:`)
 <summary><b>🧪 Tests & Quality</b></summary>
 
 - ✅ Infrastructure: Vitest + React Testing Library + MSW
-- ✅ **206/206 backend tests** (26 files — repos, services, HTTP routes)
+- ✅ **212/212 backend tests** (26 files — repos, services, HTTP routes)
 - ✅ **134/134 frontend tests** (23 files — hooks, flows, components, services)
 - ✅ Covered hooks: useGamesPage, usePlayersPage, useNewPlayPage, useDashboard, useGameStatsPage, usePlayerStatsPage
 - ✅ HTTP routes: 8 supertest suites (auth, games, players, plays, stats, bgg, labels, data)

--- a/backend/__tests__/unit/repositories/BGGRepository.test.ts
+++ b/backend/__tests__/unit/repositories/BGGRepository.test.ts
@@ -175,3 +175,33 @@ describe('BGGRepository.getLanguageStatus', () => {
     expect(s.pending_es).toBe(0)
   })
 })
+
+describe('BGGRepository.upsertThumbnail', () => {
+  beforeEach(() => {
+    repo.upsertCatalogBatch([
+      { bgg_id: 266192, name: 'Wingspan', year_published: 2019, is_expansion: 0,
+        rank: null, bgg_rating: null, users_rated: null,
+        abstracts_rank: null, cgs_rank: null, childrensgames_rank: null,
+        familygames_rank: null, partygames_rank: null, strategygames_rank: 5,
+        thematic_rank: null, wargames_rank: null },
+    ])
+    repo.syncCatalogToLanguage()
+  })
+
+  it('écrit le thumbnail dans bgg_catalog_language', () => {
+    repo.upsertThumbnail(266192, 'https://example.com/thumb.jpg')
+    const row = conn.db.prepare('SELECT thumbnail FROM bgg_catalog_language WHERE bgg_id = 266192').get() as { thumbnail: string }
+    expect(row.thumbnail).toBe('https://example.com/thumb.jpg')
+  })
+
+  it('écrase un thumbnail existant', () => {
+    repo.upsertThumbnail(266192, 'https://example.com/old.jpg')
+    repo.upsertThumbnail(266192, 'https://example.com/new.jpg')
+    const row = conn.db.prepare('SELECT thumbnail FROM bgg_catalog_language WHERE bgg_id = 266192').get() as { thumbnail: string }
+    expect(row.thumbnail).toBe('https://example.com/new.jpg')
+  })
+
+  it('ne plante pas sur un bgg_id absent de bgg_catalog_language', () => {
+    expect(() => repo.upsertThumbnail(99999, 'https://example.com/thumb.jpg')).not.toThrow()
+  })
+})

--- a/backend/database/migrations/026_add_thumbnail_to_bgg_catalog_language.sql
+++ b/backend/database/migrations/026_add_thumbnail_to_bgg_catalog_language.sql
@@ -1,0 +1,1 @@
+ALTER TABLE bgg_catalog_language ADD COLUMN thumbnail TEXT;

--- a/backend/repositories/BGGRepository.ts
+++ b/backend/repositories/BGGRepository.ts
@@ -7,6 +7,7 @@ type BggRow = {
   name: string
   year_published: number | null
   is_expansion: number
+  thumbnail: string | null
   rank: number | null
   bgg_rating: number | null
   abstracts_rank: number | null
@@ -40,6 +41,7 @@ export class BGGRepository {
     const starts   = `${query}%`
     const rows = this.db.prepare(`
       SELECT c.bgg_id, COALESCE(l.name_en, c.name) AS name, c.year_published, c.is_expansion,
+             l.thumbnail,
              c.rank, c.bgg_rating,
              c.abstracts_rank, c.cgs_rank, c.childrensgames_rank,
              c.familygames_rank, c.partygames_rank, c.strategygames_rank,
@@ -55,13 +57,14 @@ export class BGGRepository {
     `).all(contains, contains, contains, contains, starts, starts, starts, limit) as BggRow[]
 
     return rows.map(r => ({
-      bgg_id:        r.bgg_id,
-      name:          r.name,
+      bgg_id:         r.bgg_id,
+      name:           r.name,
       year_published: r.year_published ?? undefined,
-      is_expansion:  !!r.is_expansion,
-      rank:          r.rank ?? undefined,
-      bgg_rating:    r.bgg_rating ?? undefined,
-      game_types:    deriveGameTypes(r),
+      is_expansion:   !!r.is_expansion,
+      thumbnail:      r.thumbnail ?? undefined,
+      rank:           r.rank ?? undefined,
+      bgg_rating:     r.bgg_rating ?? undefined,
+      game_types:     deriveGameTypes(r),
     }))
   }
 
@@ -141,6 +144,12 @@ export class BGGRepository {
       }
     })
     upsert(rows)
+  }
+
+  upsertThumbnail(bgg_id: number, thumbnail: string): void {
+    this.db.prepare(
+      'UPDATE bgg_catalog_language SET thumbnail = ? WHERE bgg_id = ?'
+    ).run(thumbnail, bgg_id)
   }
 
   upsertCatalogLanguageBatch(rows: BggCatalogLanguageRow[]): void {

--- a/backend/routes/bgg.ts
+++ b/backend/routes/bgg.ts
@@ -140,7 +140,10 @@ export function createBggRouter(bggRepo: BGGRepository): Router {
 
   router.get('/game/:bggId', async (req, res) => {
     try {
-      const data = await bggService.getGameDetails(Number(req.params.bggId))
+      const bggId = Number(req.params.bggId)
+      const data = await bggService.getGameDetails(bggId)
+      const thumbnail = data?.thumbnail || data?.image
+      if (thumbnail) bggRepo.upsertThumbnail(bggId, thumbnail)
       res.json(data)
     } catch {
       res.status(502).json({ error: 'BGG API unavailable' })

--- a/backend/routes/bgg.ts
+++ b/backend/routes/bgg.ts
@@ -142,8 +142,9 @@ export function createBggRouter(bggRepo: BGGRepository): Router {
     try {
       const bggId = Number(req.params.bggId)
       const data = await bggService.getGameDetails(bggId)
-      const thumbnail = data?.thumbnail || data?.image
-      if (thumbnail) bggRepo.upsertThumbnail(bggId, thumbnail)
+      if (data?.thumbnail) {
+        try { bggRepo.upsertThumbnail(bggId, data.thumbnail) } catch { /* best-effort */ }
+      }
       res.json(data)
     } catch {
       res.status(502).json({ error: 'BGG API unavailable' })

--- a/src/features/bgg/BGGSearch.tsx
+++ b/src/features/bgg/BGGSearch.tsx
@@ -43,9 +43,10 @@ export default function BGGSearch({ onGameSelect, onClose }: BGGSearchProps) {
       const results = await bggApiService.searchGames(trimmed);
       setSearchResults(results);
 
-      // Enrich thumbnails + years sequentially; abort if a new search starts
+      // Enrich thumbnails sequentially for results not yet cached locally; abort if a new search starts
       for (const result of results) {
         if (enrichmentIdRef.current !== searchId) break;
+        if (result.thumbnail) continue;
         try {
           const details = await bggApiService.getGameDetails(result.bgg_id);
           if (enrichmentIdRef.current !== searchId) break;


### PR DESCRIPTION
## Summary

- Adds `thumbnail TEXT` column to `bgg_catalog_language` (migration 026)
- `GET /api/v1/bgg/game/:bggId` persists the thumbnail returned by geekdo into the local table after each fetch
- `BGGRepository.search()` now returns `thumbnail` from the local DB directly in search results
- `BGGSearch.tsx` skips the `getGameDetails` enrichment call for results that already have a cached thumbnail

## Behaviour

First search: thumbnail missing → enrichment loop calls geekdo, stores thumbnail in DB.
Subsequent searches: thumbnail present in search result → no geekdo call, instant display.

Enrichment is progressive — the local catalog grows richer with each game consulted, with no batch import required.

## Test plan

- [ ] Run backend: `npm run test:run` in `backend/` — 209 tests green
- [ ] Run frontend: `npm run test:run` — 134 tests green
- [ ] Start dev servers, search a game (e.g. "Catan"), confirm thumbnail appears after first click
- [ ] Search same game again, confirm thumbnail appears immediately in search results (no geekdo call in Network tab)
- [ ] Verify new DB column exists: `SELECT bgg_id, thumbnail FROM bgg_catalog_language LIMIT 5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)