### PR TITLE
fix(ux): Design Audit Sprint B — régressions PR #91 + GameDetail §24-33

### DIFF
--- a/docs/DESIGN_AUDIT.md
+++ b/docs/DESIGN_AUDIT.md
@@ -2,7 +2,7 @@
 
 **Portée** : revue exhaustive page par page (`src/features/**/View.tsx`), dialogs (`src/features/**/dialogs/*.tsx`), primitives UI (`src/shared/components/ui/*.tsx`), et patterns transverses.
 **Date** : 2026-04-18
-**Mise à jour** : 2026-04-30 — nettoyage post-sprints + fix §1 Login + fix §11 Settings + fix §11-12-14-15-16 Dashboard. Items résolus retirés : §10 (timestamps fictifs Dashboard), §20 (empty state Games), §28 (double h1 GameDetail), §59 (bouton bleu BGGSearch), §74 (placeholder "coming soon" Stats Player), §75 (i18n Stats Player), §86 (Reset sans AlertDialog), §104-107 (DeleteGameDialog), §114-119 (EditPlayerDialog), §121 (DeletePlayerDialog). PR #85 (i18n 9 composants) et refactors dialogs ont résolu la majorité du Sprint 1 et Sprint 2.
+**Mise à jour** : 2026-05-01 — Sprint A terminé (PR #95) + fix régressions PR #91 (labels, GameForm, i18n, bottom-nav) + Sprint B §24-30 GamesPageView + GameDetailView. Items résolus retirés : §10 (timestamps fictifs Dashboard), §20 (empty state Games), §28 (double h1 GameDetail), §59 (bouton bleu BGGSearch), §74 (placeholder "coming soon" Stats Player), §75 (i18n Stats Player), §86 (Reset sans AlertDialog), §104-107 (DeleteGameDialog), §114-119 (EditPlayerDialog), §121 (DeletePlayerDialog). PR #85 (i18n 9 composants) et refactors dialogs ont résolu la majorité du Sprint 1 et Sprint 2.
 **Méthode** : lecture ligne-à-ligne du code, cross-reference avec les spécifications WCAG 2.1 AA, audit de cohérence entre pages et entre modes clair/sombre.
 
 ---
@@ -139,10 +139,10 @@ La page **la plus dense** d'information de l'app. Chaque carte de jeu affiche : 
 | 21 | ✅ | ~~`DropdownMenuContent` hardcodé dark.~~ → **Résolu** : `<DropdownMenuContent align="end">` sans classes couleur — tokens shadcn. Items : `dark:` préfixés via `dropdownItemClass` dans `gameHelpers.ts`. | — |
 | 22 | ✅ | ~~Double point d'entrée Add Game simultanément visible.~~ → **Résolu** : FAB `md:hidden` (mobile only), trigger header enveloppé dans `hidden md:flex` (desktop only). | — |
 | 23 | ✅ | ~~Actions desktop carte : `p-2` + `w-4 h-4` ≈ 32 px.~~ → **Résolu** : `p-2.5` + `w-5 h-5` ≈ 44 px sur les 4 boutons (Eye, ChartLineUp, PencilSimple, Trash). | — |
-| 24 | 🟡 | Le bouton `caret` d'expand/collapse est un `<button>` imbriqué dans une grille de badges, elle-même dans un container qui peut être cliquable (suivant le contexte). **Boutons imbriqués = HTML invalide + comportement lecteur d'écran cassé + navigation clavier confuse**. | Séparer : la carte n'est pas cliquable globalement, les actions (ouvrir, expand) sont des boutons explicites et distincts. |
-| 25 | 🟡 | Badge « Extension » : `<Badge variant="outline" className="border-amber-500/40 text-amber-400">`. Calcul en mode clair : `#f59e0b` (amber-400) sur `#ffffff` ≈ **2.3:1**. Échec AA. Et la bordure `border-amber-500/40` est à peine visible. | Tokens sémantiques par mode : `dark:text-amber-400 dark:border-amber-500/40 text-amber-700 border-amber-600/60`. |
-| 26 | 🟢 | Stats en haut : 3 cartes avec des couleurs arbitraires — `text-emerald-400` pour « Jeux », `text-blue-400` pour « Joueurs actifs », `text-purple-400` pour « Cette semaine ». Le choix de couleur ne véhicule aucune information sémantique — c'est décoratif. Pour l'utilisateur, c'est du bruit. | Adopter une couleur unique neutre (`text-foreground`) et réserver les accents pour les statuts (positif/négatif) et les modes de session. |
-| 27 | 🟢 | Incohérence de palette : dans `GamesPageView`, mode `competitive=rouge`, `cooperative=bleu`, `campaign=violet`, `hybrid=orange`. Dans `GameStatsView.distribution`, mode `cooperative=bleu` (OK) mais `hybrid=vert`. Dans `NewPlayView`, `competitive=orange`. Au moins **3 mappings incompatibles** pour le même concept. | Fichier unique `src/shared/theme/gameModeColors.ts` exportant un objet `{ competitive: { bg, text, border }, cooperative: {...}, ... }`, importé partout. Supprimer les classes inline pour ces couleurs. |
+| 24 | ✅ | ~~Le bouton `caret` d'expand/collapse est un `<button>` imbriqué dans une grille de badges, elle-même dans un container qui peut être cliquable.~~ → **Analysé 2026-05-01** : le caret est un `<button>` autonome dans la zone de badges, la `<Card>` n'est pas un élément interactif. HTML valide, pas de boutons imbriqués. Aucune action requise. | — |
+| 25 | ✅ | ~~Badge « Extension » : `text-amber-400` sur blanc ≈ 2.3:1. Échec AA.~~ → **Résolu 2026-05-01** : `border-amber-600/60 text-amber-700 dark:border-amber-500/40 dark:text-amber-400`. WCAG AA conforme en mode clair. | — |
+| 26 | ✅ | ~~Stats en haut : couleurs arbitraires emerald/blue/purple sans valeur sémantique.~~ → **Résolu 2026-05-01** : `text-emerald-700/blue-700/purple-700 dark:*-400` → `text-foreground` sur les 3 valeurs. | — |
+| 27 | ✅ | ~~Incohérence de palette gameModeColors entre pages.~~ → **Résolu PR #91** : `src/shared/theme/gameModeColors.ts` créé, importé dans GamesPageView, GameStatsView, NewPlayView. | — |
 
 ### Accessibilité
 
@@ -152,7 +152,7 @@ La page **la plus dense** d'information de l'app. Chaque carte de jeu affiche : 
 
 ### Résumé
 
-Page informativement riche mais cognitivement lourde. Critiques restantes : §21 (DropdownMenu hardcodé dark), §22 (double point d'entrée Add), §23 (zones tactiles cartes).
+Page informativement riche mais cognitivement lourde. §24-27 tous résolus. Aucun finding restant dans cette section.
 
 ---
 
@@ -160,24 +160,24 @@ Page informativement riche mais cognitivement lourde. Critiques restantes : §21
 
 ### Première impression
 
-Page vitrine d'un jeu : hero image, titre, badges, stats, puis onglets Overview / Expansions / Characters. Bien structurée sur desktop. Le double `<h1>` a été corrigé. Les problèmes restants concernent `GameOverview` (hardcodé dark, § 29) et la bottom-nav toujours active (§ 30).
+Page vitrine d'un jeu : hero image, titre, badges, stats, puis onglets Overview / Expansions / Characters. Bien structurée sur desktop. Le double `<h1>` a été corrigé. §29 (GameOverview tokens) et §30 (bottom-nav) résolus le 2026-05-01. Restant : §31 (kebab mobile), §32 (header bg hardcodé).
 
 ### Constats détaillés
 
 | # | Sévérité | Finding | Recommandation |
 |---|---|---|---|
-| 29 | 🔴 | `GameOverview` (composant imbriqué) est **entièrement hardcodé sombre** : `bg-slate-800/50`, `border-slate-700/50`, `text-white`, `text-slate-300`, `text-slate-400`. Le wrapper externe applique `darkMode ? "" : "bg-white text-slate-900"` mais les cartes internes restent sombres. En mode clair, blocs sombres flottant au milieu d'une page claire — **break visuel majeur**. | Refactor complet de `GameOverview` : remplacer tous les `bg-slate-800/*`, `border-slate-700/*`, `text-white`, `text-slate-300` par les tokens shadcn (`bg-card`, `border-border`, `text-foreground`, `text-muted-foreground`). Une passe globale — ~40 remplacements. |
-| 30 | 🔴 | Bottom nav mobile : `<button className="... text-primary">` pour l'onglet « Games » sans condition. Le bouton est **toujours en state actif** peu importe la page courante. Sur la Dashboard, l'onglet « Games » est bleu-actif → incohérence mentale. | Dériver `isActive` depuis `currentView`/route : `className={currentView === 'games' ? 'text-primary' : 'text-muted-foreground'}`. À faire pour les 4 onglets (Dashboard, Games, Players, Stats). |
-| 31 | 🟡 | Le kebab mobile mélange **5 items** dont 3 sont des onglets de navigation (« Overview », « Expansions », « Characters ») et 2 sont des actions (« Edit », « Delete »). Sur mobile, c'est le seul moyen d'accéder aux onglets Expansions/Characters → comportement non-standard. | Séparer : en mobile, afficher les **onglets visiblement** en haut de la page (comme en desktop, `<TabsList>` horizontal scrollable si nécessaire), et réserver le kebab aux actions de gestion (Edit/Delete). |
-| 32 | 🟡 | Header `sticky top-0 z-10 bg-slate-800/50 backdrop-blur-sm`. Fond sombre hardcodé qui flotte en mode clair au-dessus du contenu clair : rupture visuelle. Double contrainte : sur sticky + bottom-nav fixed, l'utilisateur perd ~112 px d'écran utile en permanence sur mobile. | (a) Theme-aware : `bg-background/80` ; (b) envisager `hide-on-scroll` : cacher la header quand on scrolle vers le bas (pattern IntersectionObserver), réapparaître au scroll up. Gain écran utile : ~64 px. |
-| 33 | 🟡 | Preview Expansions/Characters sur desktop : un lien « Gérer » est affiché mais les cartes d'extension/personnage **ne sont pas cliquables**. Incohérent avec la liste de jeux où la carte est cliquable. L'utilisateur hésite — clic centré sur la carte ou sur « Gérer » ? | Soit carte cliquable + ghost-link « Gérer » retiré, soit carte non-cliquable + `hover:bg-...` retiré pour ne pas suggérer l'interactivité. |
-| 34 | 🟡 | Rating pill `<div className="bg-amber-500/20 text-amber-400 rounded-full px-3 py-1 flex items-center gap-1">` en top-right de la carte principale. Accroche visuelle forte — compétition avec le titre. En mode clair : `text-amber-400` sur `bg-amber-500/20` ≈ **2.5:1**, échec AA. | (a) Contraste : `text-amber-700` en mode clair ; (b) hiérarchie : intégrer la note dans une ligne de stats sous le titre, plus discrète. |
+| 29 | ✅ | ~~`GameOverview` entièrement hardcodé sombre : `bg-slate-800/50`, `border-slate-700/50`, `text-white`, `text-slate-300`, `text-slate-400`.~~ → **Résolu 2026-05-01** : refactor complet — `bg-card`, `border-border`, `text-foreground`, `text-muted-foreground`, `bg-muted`, `bg-muted/50`. Page wrapper `bg-gradient-to-br slate` → `bg-background`. Rating pill amber WCAG AA corrigé. | — |
+| 30 | ✅ | ~~Bottom nav mobile : onglet « Games » toujours `text-primary` peu importe la page.~~ → **Résolu 2026-05-01** : bottom-nav dupliquée inline dans `GameDetailView` supprimée. Le `<Layout>` global fournit `<BottomNavigation>` avec `useLocation()` correct. | — |
+| 31 | ✅ | ~~Le kebab mobile mélange 5 items : 3 onglets de navigation + 2 actions de gestion.~~ → **Résolu 2026-05-01** : kebab réduit aux 2 actions de gestion (Manage Expansions / Manage Characters). `<TabsList>` rendu sur toutes les tailles d'écran (suppression des blocs `hidden md:block` / `md:hidden` séparés — un seul `<Tabs>` unifié). | — |
+| 32 | ✅ | ~~Header `bg-slate-800/50 backdrop-blur-sm` hardcodé sombre.~~ → **Résolu 2026-05-01** : `bg-background/95 backdrop-blur-sm border-border`. Boutons ghost : `text-muted-foreground hover:text-foreground hover:bg-muted`. Hide-on-scroll déféré (non-bloquant). | — |
+| 33 | ✅ | ~~Preview Expansions/Characters : lien « Gérer » affiché mais cartes non-cliquables — ambiguïté UX.~~ → **Résolu 2026-05-01** : `<Card>` entier cliquable (`cursor-pointer hover:border-primary/50 transition-colors`) → navigation vers management. Bouton « Gérer » retiré, remplacé par `<CaretRight>` indicator. | — |
+| 34 | ✅ | ~~Rating pill `text-amber-400` sur `bg-amber-500/20` ≈ 2.5:1, échec AA en mode clair.~~ → **Résolu 2026-05-01** dans §29 : `bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-400`. WCAG AA conforme. | — |
 | 35 | 🟢 | `<TabsTrigger data-[state=active]:bg-primary data-[state=active]:text-primary-foreground>` : dépend du token `--primary`. À vérifier : la valeur exacte de `--primary` dans `theme.json` + que le contraste `primary-foreground/primary` est ≥ 4.5:1. |   |
 | 36 | 🟢 | Pas d'état de chargement visible pendant le fetch du game detail. React Query gère via `isLoading`, mais le composant affiche « … » ou rien → UX pauvre. | Ajouter un skeleton de page dedié (`<GameDetailSkeleton />`) avec `<Skeleton>` pour le hero, le titre, les stats. |
 
 ### Résumé
 
-La page contient **2 problèmes critiques** restants : `GameOverview` hardcodé dark (§ 29) et bottom-nav toujours active (§ 30). Tous deux sont des bugs factuels. Le refactor de `GameOverview` est le plus lourd (~40 remplacements).
+§29–§33 résolus. Restant : §35-36 🟢 (TabsTrigger contraste à vérifier, skeleton chargement).
 
 ---
 

--- a/shared/types/index.d.ts
+++ b/shared/types/index.d.ts
@@ -83,6 +83,10 @@ export interface GameFormData {
   bgg_id?: number;
   thumbnail?: string;
   playing_time?: number;
+  min_playtime?: number;
+  max_playtime?: number;
+  categories?: string[];
+  mechanics?: string[];
 }
 
 export interface GameValidationErrors {

--- a/src/features/games/GamesPageView.tsx
+++ b/src/features/games/GamesPageView.tsx
@@ -86,7 +86,7 @@ function getGameModesBadges(game: Game, t: (key: string) => string): React.React
     const colors = gameModeColors[mode] ?? gameModeFallback;
     return [
       <Badge key={mode} variant="outline" className={`${colors.badge} text-xs`}>
-        {MODE_ICONS[mode]}{t(`games.mode.${mode}`)}
+        {MODE_ICONS[mode]}{t(`games.card.modes.${mode}`)}
       </Badge>
     ];
   });
@@ -198,7 +198,7 @@ const GameCard = React.memo(function GameCard({ game, expandedGame, setExpandedG
 
                 <div className="flex flex-wrap gap-2 mb-2">
                   {game.is_expansion && (
-                    <Badge variant="outline" className="border-amber-500/40 text-amber-400 text-xs">
+                    <Badge variant="outline" className="border-amber-600/60 text-amber-700 dark:border-amber-500/40 dark:text-amber-400 text-xs">
                       {t('games.card.expansion')}
                     </Badge>
                   )}
@@ -452,17 +452,17 @@ export function GamesPageView(props: GamesPageViewProps) {
         {/* Games Stats */}
         <div className="grid grid-cols-3 gap-4 mb-6">
           <div className={statCardClass}>
-            <div className="text-2xl font-bold text-emerald-700 dark:text-emerald-400">{totalGames}</div>
+            <div className="text-2xl font-bold text-foreground">{totalGames}</div>
             <div className={statSubClass}>{t('games.stats.total')}</div>
           </div>
           <div className={statCardClass}>
-            <div className="text-2xl font-bold text-blue-700 dark:text-blue-400">
+            <div className="text-2xl font-bold text-foreground">
               {[...new Set(safeGames.map(g => g.category || 'Unknown'))].length}
             </div>
             <div className={statSubClass}>{t('games.stats.categories')}</div>
           </div>
           <div className={statCardClass}>
-            <div className="text-2xl font-bold text-purple-700 dark:text-purple-400">
+            <div className="text-2xl font-bold text-foreground">
               {averageRating > 0 ? averageRating.toFixed(1) : '0.0'}
             </div>
             <div className={statSubClass}>{t('games.stats.avg_rating')}</div>

--- a/src/features/games/detail/GameDetailView.tsx
+++ b/src/features/games/detail/GameDetailView.tsx
@@ -9,9 +9,8 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  DropdownMenuSeparator
 } from '@/shared/components/ui/dropdown-menu';
-import { ArrowLeft, Users, Clock, Star, Barbell, Calendar, Buildings, User, DotsThree, Crown, TrendUp, Gear, GameController } from '@phosphor-icons/react';
+import { ArrowLeft, Users, Clock, Star, Barbell, Calendar, Buildings, User, DotsThree, Crown, GameController, CaretRight } from '@phosphor-icons/react';
 import GameExpansionsPage from '../expansions/GameExpansionsPage';
 import GameCharactersPage from '../characters/GameCharactersPage';
 import { UseGameDetailProps } from './useGameDetail';
@@ -45,7 +44,6 @@ export default function GameDetailView({
   activeTab,
   gameTypes,
   handleNavigation,
-  tabHandlers,
   setActiveTab,
   hasExpansionHandlers,
   hasCharacterHandlers,
@@ -77,9 +75,9 @@ export default function GameDetailView({
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-100 to-slate-300 dark:from-slate-900 dark:to-slate-800">
+    <div className="min-h-screen bg-background">
       {/* Header */}
-      <div className="bg-white border-b border-slate-200 dark:bg-slate-800/50 dark:backdrop-blur-sm dark:border-b dark:border-slate-700/50 sticky top-0 z-10">
+      <div className="bg-background/95 backdrop-blur-sm border-b border-border sticky top-0 z-10">
         <div className="max-w-7xl mx-auto px-4 md:px-6 py-3 md:py-4">
           <div className="flex items-center gap-3 md:gap-4">
             <Tooltip>
@@ -88,7 +86,7 @@ export default function GameDetailView({
                   variant="ghost"
                   size="sm"
                   onClick={handleNavigation.back}
-                  className="text-slate-600 hover:text-slate-900 hover:bg-slate-100 dark:text-white/80 dark:hover:text-white dark:hover:bg-white/10 p-2"
+                  className="text-muted-foreground hover:text-foreground hover:bg-muted p-2"
                 >
                   <ArrowLeft className="w-4 h-4 md:mr-2" />
                   <span className="hidden md:inline">{t('game.detail.back')}</span>
@@ -98,8 +96,8 @@ export default function GameDetailView({
                 <p>{t('expansion.view.back_to_games')}</p>
               </TooltipContent>
             </Tooltip>
-            <div className="h-6 w-px bg-slate-300 dark:bg-slate-600 hidden md:block"></div>
-            <h1 className="text-lg md:text-xl font-semibold text-slate-900 dark:text-white flex-1 truncate">{game.name}</h1>
+            <div className="h-6 w-px bg-border hidden md:block"></div>
+            <h1 className="text-lg md:text-xl font-semibold text-foreground flex-1 truncate">{game.name}</h1>
 
             {/* Mobile Context Menu */}
             <div className="md:hidden">
@@ -107,7 +105,7 @@ export default function GameDetailView({
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" size="sm" className="text-slate-600 hover:text-slate-900 hover:bg-slate-100 dark:text-white/80 dark:hover:text-white dark:hover:bg-white/10 p-2">
+                      <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-foreground hover:bg-muted p-2">
                         <DotsThree className="w-5 h-5" />
                       </Button>
                     </DropdownMenuTrigger>
@@ -117,19 +115,6 @@ export default function GameDetailView({
                   </TooltipContent>
                 </Tooltip>
                 <DropdownMenuContent align="end" className="w-56">
-                  <DropdownMenuItem onClick={tabHandlers.setOverview}>
-                    <GameController className="w-4 h-4 mr-2" />
-                    {t('game.detail.tab.overview')}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={tabHandlers.setExpansions}>
-                    <Crown className="w-4 h-4 mr-2" />
-                    {t('expansion.view.title')} ({game.expansions?.length || 0})
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={tabHandlers.setCharacters}>
-                    <User className="w-4 h-4 mr-2" />
-                    {t('character.view.title')} ({game.characters?.length || 0})
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
                   <DropdownMenuItem onClick={handleNavigation.expansions}>
                     <Crown className="w-4 h-4 mr-2" />
                     {t('game.detail.manage_expansions')}
@@ -146,76 +131,33 @@ export default function GameDetailView({
       </div>
 
       <div className="max-w-7xl mx-auto px-4 md:px-6 py-4 md:py-8">
-        {/* Desktop Layout with Tabs */}
-        <div className="hidden md:block">
-          <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-            <TabsList className="grid w-full grid-cols-3">
-              <TabsTrigger value="overview">
-                {t('game.detail.tab.overview')}
-              </TabsTrigger>
-              <TabsTrigger value="expansions">
-                {t('expansion.view.title')} ({game.expansions?.length || 0})
-              </TabsTrigger>
-              <TabsTrigger value="characters">
-                {t('character.view.title')} ({game.characters?.length || 0})
-              </TabsTrigger>
-            </TabsList>
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+          <TabsList className="grid w-full grid-cols-3">
+            <TabsTrigger value="overview">
+              {t('game.detail.tab.overview')}
+            </TabsTrigger>
+            <TabsTrigger value="expansions">
+              {t('expansion.view.title')} ({game.expansions?.length || 0})
+            </TabsTrigger>
+            <TabsTrigger value="characters">
+              {t('character.view.title')} ({game.characters?.length || 0})
+            </TabsTrigger>
+          </TabsList>
 
-            <TabsContent value="overview" className="mt-6">
-              <GameOverview game={game} gameTypes={gameTypes} onNavigation={onNavigation} />
-            </TabsContent>
+          <TabsContent value="overview" className="mt-6 pb-32 md:pb-0">
+            <GameOverview game={game} gameTypes={gameTypes} onNavigation={onNavigation} />
+          </TabsContent>
 
-            <TabsContent value="expansions" className="mt-6">
-              {hasExpansionHandlers && <GameExpansionsPage {...expansionPageProps} />}
-            </TabsContent>
+          <TabsContent value="expansions" className="mt-6 pb-32 md:pb-0">
+            {hasExpansionHandlers && <GameExpansionsPage {...expansionPageProps} />}
+          </TabsContent>
 
-            <TabsContent value="characters" className="mt-6">
-              {hasCharacterHandlers && <GameCharactersPage {...characterPageProps} />}
-            </TabsContent>
-          </Tabs>
-        </div>
-
-        {/* Mobile Layout - Show current tab content */}
-        <div className="md:hidden pb-32">
-          {activeTab === 'overview' && <GameOverview game={game} gameTypes={gameTypes} onNavigation={onNavigation} />}
-          {activeTab === 'expansions' && hasExpansionHandlers && <GameExpansionsPage {...expansionPageProps} />}
-          {activeTab === 'characters' && hasCharacterHandlers && <GameCharactersPage {...characterPageProps} />}
-        </div>
+          <TabsContent value="characters" className="mt-6 pb-32 md:pb-0">
+            {hasCharacterHandlers && <GameCharactersPage {...characterPageProps} />}
+          </TabsContent>
+        </Tabs>
       </div>
 
-      {/* Bottom Navigation - Mobile Only */}
-      <div className="fixed bottom-0 left-0 right-0 bg-slate-100/90 dark:bg-slate-800/90 backdrop-blur-md border-t border-slate-200 dark:border-white/10 md:hidden">
-        <div className="flex justify-around items-center py-2">
-          <button
-            onClick={handleNavigation.dashboard}
-            className="flex flex-col items-center p-3 transition-colors text-slate-500 hover:text-slate-900 dark:text-white/60 dark:hover:text-white"
-          >
-            <TrendUp className="w-6 h-6 mb-1" />
-            <span className="text-xs">{t('dashboard.title')}</span>
-          </button>
-          <button
-            onClick={handleNavigation.players}
-            className="flex flex-col items-center p-3 transition-colors text-slate-500 hover:text-slate-900 dark:text-white/60 dark:hover:text-white"
-          >
-            <Users className="w-6 h-6 mb-1" />
-            <span className="text-xs">{t('players.page.title')}</span>
-          </button>
-          <button
-            onClick={handleNavigation.games}
-            className="flex flex-col items-center p-3 transition-colors text-primary"
-          >
-            <GameController className="w-6 h-6 mb-1" />
-            <span className="text-xs">{t('games.page.title')}</span>
-          </button>
-          <button
-            onClick={handleNavigation.settings}
-            className="flex flex-col items-center p-3 transition-colors text-slate-500 hover:text-slate-900 dark:text-white/60 dark:hover:text-white"
-          >
-            <Gear className="w-6 h-6 mb-1" />
-            <span className="text-xs">{t('settings.page.title')}</span>
-          </button>
-        </div>
-      </div>
     </div>
   );
 }
@@ -232,7 +174,7 @@ function GameOverview({ game, gameTypes, onNavigation }: GameOverviewProps) {
   return (
     <div>
       {/* Game Overview Card */}
-      <Card className="bg-white dark:bg-slate-800/50 border-slate-200 dark:border-slate-700/50 mb-6 md:mb-8">
+      <Card className="bg-card border-border mb-6 md:mb-8">
         <CardContent className="p-4 md:p-6">
           <div className="flex flex-col md:flex-row gap-4 md:gap-6">
             {/* Game Image */}
@@ -241,11 +183,11 @@ function GameOverview({ game, gameTypes, onNavigation }: GameOverviewProps) {
                 <img
                   src={game.image}
                   alt={game.name}
-                  className="w-24 h-24 md:w-32 md:h-32 object-cover rounded-lg border border-slate-300 dark:border-slate-600"
+                  className="w-24 h-24 md:w-32 md:h-32 object-cover rounded-lg border border-border"
                 />
               ) : (
-                <div className="w-24 h-24 md:w-32 md:h-32 bg-slate-100 dark:bg-slate-700/50 rounded-lg border border-slate-300 dark:border-slate-600 flex items-center justify-center">
-                  <GameController className="w-8 h-8 md:w-12 md:h-12 text-slate-500 dark:text-slate-400" />
+                <div className="w-24 h-24 md:w-32 md:h-32 bg-muted rounded-lg border border-border flex items-center justify-center">
+                  <GameController className="w-8 h-8 md:w-12 md:h-12 text-muted-foreground" />
                 </div>
               )}
             </div>
@@ -254,13 +196,13 @@ function GameOverview({ game, gameTypes, onNavigation }: GameOverviewProps) {
             <div className="flex-1">
               <div className="flex flex-col md:flex-row md:items-start md:justify-between mb-4">
                 <div className="mb-4 md:mb-0">
-                  <h2 className="text-xl md:text-2xl font-bold text-slate-900 dark:text-white mb-2">{game.name}</h2>
+                  <h2 className="text-xl md:text-2xl font-bold text-foreground mb-2">{game.name}</h2>
                   {game.description && (
-                    <p className="text-slate-600 dark:text-slate-300 mb-4 text-sm md:text-base max-w-2xl">{game.description}</p>
+                    <p className="text-muted-foreground mb-4 text-sm md:text-base max-w-2xl">{game.description}</p>
                   )}
                 </div>
                 {game.bgg_rating && (
-                  <div className="flex items-center gap-1 bg-amber-500/20 text-amber-400 px-3 py-1 rounded-full self-start">
+                  <div className="flex items-center gap-1 bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-400 px-3 py-1 rounded-full self-start">
                     <Star className="w-3 h-3 md:w-4 md:h-4 fill-current" />
                     <span className="font-medium text-sm">{game.bgg_rating}/10</span>
                   </div>
@@ -269,24 +211,24 @@ function GameOverview({ game, gameTypes, onNavigation }: GameOverviewProps) {
 
               {/* Game Stats */}
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 md:gap-4 mb-4">
-                <div className="flex items-center gap-2 text-slate-600 dark:text-slate-300">
+                <div className="flex items-center gap-2 text-muted-foreground">
                   <Users className="w-4 h-4 text-primary" />
                   <span className="text-sm">{game.min_players}-{game.max_players} {t('games.card.players')}</span>
                 </div>
                 {game.duration && (
-                  <div className="flex items-center gap-2 text-slate-600 dark:text-slate-300">
+                  <div className="flex items-center gap-2 text-muted-foreground">
                     <Clock className="w-4 h-4 text-primary" />
                     <span className="text-sm">{game.duration}</span>
                   </div>
                 )}
                 {game.weight && (
-                  <div className="flex items-center gap-2 text-slate-600 dark:text-slate-300">
+                  <div className="flex items-center gap-2 text-muted-foreground">
                     <Barbell className="w-4 h-4 text-primary" />
                     <span className="text-sm">{t('game.detail.weight_complexity')} {game.weight}/5</span>
                   </div>
                 )}
                 {game.year_published && (
-                  <div className="flex items-center gap-2 text-slate-600 dark:text-slate-300">
+                  <div className="flex items-center gap-2 text-muted-foreground">
                     <Calendar className="w-4 h-4 text-primary" />
                     <span className="text-sm">{game.year_published}</span>
                   </div>
@@ -296,13 +238,13 @@ function GameOverview({ game, gameTypes, onNavigation }: GameOverviewProps) {
               {/* Additional Info */}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-3 md:gap-4 mb-4">
                 {game.publisher && (
-                  <div className="flex items-center gap-2 text-slate-600 dark:text-slate-300">
+                  <div className="flex items-center gap-2 text-muted-foreground">
                     <Buildings className="w-4 h-4 text-primary" />
                     <span className="text-sm">{game.publisher}</span>
                   </div>
                 )}
                 {game.designer && (
-                  <div className="flex items-center gap-2 text-slate-600 dark:text-slate-300">
+                  <div className="flex items-center gap-2 text-muted-foreground">
                     <User className="w-4 h-4 text-primary" />
                     <span className="text-sm">{game.designer}</span>
                   </div>
@@ -318,12 +260,12 @@ function GameOverview({ game, gameTypes, onNavigation }: GameOverviewProps) {
                     </Badge>
                   ))}
                   {game.category && (
-                    <Badge variant="outline" className="border-slate-300 dark:border-slate-600 text-slate-600 dark:text-slate-300 text-xs">
+                    <Badge variant="outline" className="border-border text-muted-foreground text-xs">
                       {game.category}
                     </Badge>
                   )}
                   {game.difficulty && (
-                    <Badge variant="outline" className="border-slate-300 dark:border-slate-600 text-slate-600 dark:text-slate-300 text-xs">
+                    <Badge variant="outline" className="border-border text-muted-foreground text-xs">
                       {game.difficulty}
                     </Badge>
                   )}
@@ -337,98 +279,90 @@ function GameOverview({ game, gameTypes, onNavigation }: GameOverviewProps) {
       {/* Quick Overview of Extensions and Characters - Desktop Only */}
       <div className="hidden md:grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Extensions Preview */}
-        <Card className="bg-white dark:bg-slate-800/50 border-slate-200 dark:border-slate-700/50">
+        <Card
+          className="bg-card border-border cursor-pointer hover:border-primary/50 transition-colors"
+          onClick={() => onNavigation('game-expansions', game.game_id, 'game-detail')}
+        >
           <CardHeader>
             <div className="flex items-center justify-between">
-              <CardTitle className="text-slate-900 dark:text-white flex items-center gap-2">
+              <CardTitle className="text-foreground flex items-center gap-2">
                 <Crown className="w-5 h-5 text-primary" />
                 {t('expansion.view.title')} ({game.expansions?.length || 0})
               </CardTitle>
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => onNavigation('game-expansions', game.game_id, 'game-detail')}
-                className="text-xs"
-              >
-                {t('game.detail.manage')}
-              </Button>
+              <CaretRight className="w-4 h-4 text-muted-foreground" />
             </div>
           </CardHeader>
           <CardContent>
             {game.expansions && game.expansions.length > 0 ? (
               <div className="space-y-3">
                 {game.expansions.slice(0, 3).map((expansion: GameExpansion) => (
-                  <div key={expansion.expansion_id} className="flex items-center justify-between p-3 bg-slate-100/50 dark:bg-slate-700/30 rounded-lg">
+                  <div key={expansion.expansion_id} className="flex items-center justify-between p-3 bg-muted/50 rounded-lg">
                     <div>
-                      <h4 className="text-slate-900 dark:text-white font-medium">{expansion.name}</h4>
+                      <h4 className="text-foreground font-medium">{expansion.name}</h4>
                       {expansion.year_published && (
-                        <p className="text-slate-500 dark:text-slate-400 text-sm">{expansion.year_published}</p>
+                        <p className="text-muted-foreground text-sm">{expansion.year_published}</p>
                       )}
                     </div>
                   </div>
                 ))}
                 {game.expansions.length > 3 && (
-                  <p className="text-slate-500 dark:text-slate-400 text-sm text-center">
+                  <p className="text-muted-foreground text-sm text-center">
                     {game.expansions.length - 3} {t('game.detail.more_items')}
                   </p>
                 )}
               </div>
             ) : (
-              <p className="text-slate-500 dark:text-slate-400 text-sm">{t('game.detail.no_expansions')}</p>
+              <p className="text-muted-foreground text-sm">{t('game.detail.no_expansions')}</p>
             )}
           </CardContent>
         </Card>
 
         {/* Characters Preview */}
-        <Card className="bg-white dark:bg-slate-800/50 border-slate-200 dark:border-slate-700/50">
+        <Card
+          className="bg-card border-border cursor-pointer hover:border-primary/50 transition-colors"
+          onClick={() => onNavigation('game-characters', game.game_id, 'game-detail')}
+        >
           <CardHeader>
             <div className="flex items-center justify-between">
-              <CardTitle className="text-slate-900 dark:text-white flex items-center gap-2">
+              <CardTitle className="text-foreground flex items-center gap-2">
                 <User className="w-5 h-5 text-primary" />
                 {t('character.view.title')} ({game.characters?.length || 0})
               </CardTitle>
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => onNavigation('game-characters', game.game_id, 'game-detail')}
-                className="text-xs"
-              >
-                {t('game.detail.manage')}
-              </Button>
+              <CaretRight className="w-4 h-4 text-muted-foreground" />
             </div>
           </CardHeader>
           <CardContent>
             {game.characters && game.characters.length > 0 ? (
               <div className="space-y-3">
                 {game.characters.slice(0, 3).map((character: GameCharacter) => (
-                  <div key={character.character_id} className="flex items-center gap-3 p-3 bg-slate-100/50 dark:bg-slate-700/30 rounded-lg">
+                  <div key={character.character_id} className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg">
                     {character.avatar ? (
                       <img
                         src={character.avatar}
                         alt={character.name}
-                        className="w-10 h-10 rounded-full object-cover border border-slate-300 dark:border-slate-600"
+                        className="w-10 h-10 rounded-full object-cover border border-border"
                       />
                     ) : (
-                      <div className="w-10 h-10 bg-slate-200 dark:bg-slate-600 rounded-full flex items-center justify-center">
-                        <User className="w-6 h-6 text-slate-500 dark:text-slate-400" />
+                      <div className="w-10 h-10 bg-muted rounded-full flex items-center justify-center">
+                        <User className="w-6 h-6 text-muted-foreground" />
                       </div>
                     )}
                     <div>
-                      <h4 className="text-slate-900 dark:text-white font-medium">{character.name}</h4>
+                      <h4 className="text-foreground font-medium">{character.name}</h4>
                       {character.description && (
-                        <p className="text-slate-500 dark:text-slate-400 text-sm">{character.description}</p>
+                        <p className="text-muted-foreground text-sm">{character.description}</p>
                       )}
                     </div>
                   </div>
                 ))}
                 {game.characters.length > 3 && (
-                  <p className="text-slate-500 dark:text-slate-400 text-sm text-center">
+                  <p className="text-muted-foreground text-sm text-center">
                     {game.characters.length - 3} {t('game.detail.more_items')}
                   </p>
                 )}
               </div>
             ) : (
-              <p className="text-slate-500 dark:text-slate-400 text-sm">{t('game.detail.no_characters')}</p>
+              <p className="text-muted-foreground text-sm">{t('game.detail.no_characters')}</p>
             )}
           </CardContent>
         </Card>

--- a/src/features/games/dialogs/AddGameDialog.tsx
+++ b/src/features/games/dialogs/AddGameDialog.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/shared/components/ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/shared/components/ui/dialog';
 import { Button } from '@/shared/components/ui/button';
 import { Plus, Link } from '@phosphor-icons/react';
 import BGGSearch from '@/features/bgg/BGGSearch';
@@ -15,9 +15,12 @@ export default function AddGameDialog({ isOpen, onOpenChange, formData, onFormDa
 
   return (
     <Dialog open={isOpen} onOpenChange={(v) => { onOpenChange(v); if(!v) onResetForm(); }}>
-      <DialogTrigger asChild><Button><Plus className="mr-2 h-4 w-4" /> Ajouter un jeu</Button></DialogTrigger>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
-        <DialogHeader><DialogTitle>Ajouter un nouveau jeu</DialogTitle></DialogHeader>
+      <DialogTrigger asChild><Button><Plus className="mr-2 h-4 w-4" /> {t('games.add_dialog.title')}</Button></DialogTrigger>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto" onInteractOutside={(e) => e.preventDefault()}>
+        <DialogHeader>
+          <DialogTitle>{t('games.add_dialog.title')}</DialogTitle>
+          <DialogDescription>{t('games.add_dialog.description')}</DialogDescription>
+        </DialogHeader>
 
         <Button variant="outline" className="w-full mb-4 border-teal-600" onClick={() => onBGGSearchToggle(true)}>
           <Link className="mr-2 h-4 w-4" /> {t('games.form.bgg_search')}
@@ -33,7 +36,7 @@ export default function AddGameDialog({ isOpen, onOpenChange, formData, onFormDa
           onRemoveCharacter={handleRemoveCharacter}
         />
 
-        <Button className="w-full mt-4 bg-teal-600" onClick={onAddGame}>Enregistrer le jeu</Button>
+        <Button className="w-full mt-4" onClick={onAddGame}>{t('games.add_dialog.submit')}</Button>
       </DialogContent>
     </Dialog>
   );

--- a/src/features/games/dialogs/EditGameDialog.tsx
+++ b/src/features/games/dialogs/EditGameDialog.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shared/components/ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/shared/components/ui/dialog';
 import { Button } from '@/shared/components/ui/button';
 import { Link } from '@phosphor-icons/react';
 import BGGSearch from '@/features/bgg/BGGSearch';
@@ -29,8 +29,11 @@ export default function EditGameDialog({ isOpen, onOpenChange, formData, onFormD
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
-        <DialogHeader><DialogTitle>Modifier : {formData.name}</DialogTitle></DialogHeader>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto" onInteractOutside={(e) => e.preventDefault()}>
+        <DialogHeader>
+          <DialogTitle>{t('games.edit_dialog.title')} : {formData.name}</DialogTitle>
+          <DialogDescription>{t('games.edit_dialog.description')}</DialogDescription>
+        </DialogHeader>
 
         <Button variant="outline" className="w-full mb-4 border-teal-600" onClick={() => onBGGSearchToggle(true)}>
           <Link className="mr-2 h-4 w-4" /> {t('games.form.bgg_search')}
@@ -51,7 +54,7 @@ export default function EditGameDialog({ isOpen, onOpenChange, formData, onFormD
           onRemoveCharacter={handleRemoveCharacter}
         />
 
-        <Button className="w-full mt-4 bg-orange-600" onClick={onUpdateGame}>Mettre à jour</Button>
+        <Button className="w-full mt-4" onClick={onUpdateGame}>{t('games.edit_dialog.submit')}</Button>
       </DialogContent>
     </Dialog>
   );

--- a/src/features/games/dialogs/GameForm.tsx
+++ b/src/features/games/dialogs/GameForm.tsx
@@ -5,10 +5,11 @@ import { Label } from '@/shared/components/ui/label';
 import { Textarea } from '@/shared/components/ui/textarea';
 import { Checkbox } from '@/shared/components/ui/checkbox';
 import { Button } from '@/shared/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/components/ui/select';
 import { gameModeColors } from '@/shared/theme/gameModeColors';
 import { useLabels } from '@/shared/hooks/useLabels';
 
-import type { GameFormData, GameValidationErrors, GameCharacter } from '../../../../shared/types/index';
+import type { GameFormData, GameValidationErrors, GameCharacter, GameExpansion } from '../../../../shared/types/index';
 
 interface GameFormProps {
   formData: GameFormData;
@@ -17,6 +18,10 @@ interface GameFormProps {
   onCharacterChange: (index: number, field: keyof GameCharacter, value: GameCharacter[keyof GameCharacter]) => void;
   onAddCharacter: () => void;
   onRemoveCharacter: (index: number) => void;
+}
+
+function formatExpansion(exp: GameExpansion): string {
+  return exp.year_published ? `${exp.name} (${exp.year_published})` : exp.name;
 }
 
 export default function GameForm({
@@ -30,31 +35,145 @@ export default function GameForm({
   const { t } = useLabels();
 
   return (
-    <div className="space-y-6 py-4">
-      <div className="space-y-4">
-        <div>
-          <Label htmlFor="name">{t('games.form.name.label')} *</Label>
-          <Input
-            id="name"
-            value={formData.name}
-            onChange={(e) => onChange('name', e.target.value)}
-            className={errors.name ? 'border-red-500' : ''}
-          />
-          {errors.name && <p className="text-red-400 text-xs mt-1">{errors.name}</p>}
-        </div>
+    <div className="space-y-4 py-2">
 
-        <div className="grid grid-cols-2 gap-4">
-          <div>
-            <Label>{t('games.form.min_players.label')}</Label>
-            <Input type="number" value={formData.min_players} onChange={(e) => onChange('min_players', parseInt(e.target.value))} />
-          </div>
-          <div>
-            <Label>{t('games.form.max_players.label')}</Label>
-            <Input type="number" value={formData.max_players} onChange={(e) => onChange('max_players', parseInt(e.target.value))} />
-          </div>
+      {/* Name */}
+      <div>
+        <Label htmlFor="name">{t('games.form.name.label')} *</Label>
+        <Input
+          id="name"
+          value={formData.name}
+          onChange={(e) => onChange('name', e.target.value)}
+          className={errors.name ? 'border-destructive' : ''}
+          placeholder={t('games.form.name.placeholder')}
+        />
+        {errors.name && <p className="text-destructive text-xs mt-1">{errors.name}</p>}
+      </div>
+
+      {/* Image + Thumbnail */}
+      <div>
+        <Label htmlFor="image">{t('games.form.image.label')}</Label>
+        <Input
+          id="image"
+          value={formData.image}
+          onChange={(e) => onChange('image', e.target.value)}
+          className={errors.image ? 'border-destructive' : ''}
+          placeholder="https://..."
+        />
+        {errors.image && <p className="text-destructive text-xs mt-1">{errors.image}</p>}
+      </div>
+      <div>
+        <Label htmlFor="thumbnail">{t('games.form.thumbnail.label')}</Label>
+        <Input
+          id="thumbnail"
+          value={formData.thumbnail ?? ''}
+          onChange={(e) => onChange('thumbnail', e.target.value)}
+          placeholder="https://..."
+        />
+      </div>
+
+      {/* Players */}
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <Label>{t('games.form.min_players.label')}</Label>
+          <Input
+            type="number"
+            min="1"
+            value={formData.min_players}
+            onChange={(e) => onChange('min_players', parseInt(e.target.value) || 1)}
+            className={errors.min_players ? 'border-destructive' : ''}
+          />
+          {errors.min_players && <p className="text-destructive text-xs mt-1">{errors.min_players}</p>}
+        </div>
+        <div>
+          <Label>{t('games.form.max_players.label')}</Label>
+          <Input
+            type="number"
+            min="1"
+            value={formData.max_players}
+            onChange={(e) => onChange('max_players', parseInt(e.target.value) || 1)}
+            className={errors.max_players ? 'border-destructive' : ''}
+          />
+          {errors.max_players && <p className="text-destructive text-xs mt-1">{errors.max_players}</p>}
         </div>
       </div>
 
+      {/* Duration + Age */}
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <Label htmlFor="duration">{t('games.form.duration.label')}</Label>
+          <Input
+            id="duration"
+            value={formData.duration}
+            onChange={(e) => onChange('duration', e.target.value)}
+            placeholder={t('games.form.duration.placeholder')}
+          />
+        </div>
+        <div>
+          <Label htmlFor="age_min">{t('games.form.age_min.label')}</Label>
+          <Input
+            id="age_min"
+            type="number"
+            min="1"
+            value={formData.age_min}
+            onChange={(e) => onChange('age_min', parseInt(e.target.value) || 1)}
+          />
+        </div>
+      </div>
+
+      {/* Playtime min / recommended / max */}
+      <div className="grid grid-cols-3 gap-4">
+        <div>
+          <Label htmlFor="min_playtime">{t('games.form.min_playtime.label')}</Label>
+          <Input
+            id="min_playtime"
+            type="number"
+            min="0"
+            value={formData.min_playtime ?? ''}
+            onChange={(e) => onChange('min_playtime', parseInt(e.target.value) || undefined)}
+            placeholder="—"
+          />
+        </div>
+        <div>
+          <Label htmlFor="playing_time">{t('games.form.playing_time.label')}</Label>
+          <Input
+            id="playing_time"
+            type="number"
+            min="0"
+            value={formData.playing_time ?? ''}
+            onChange={(e) => onChange('playing_time', parseInt(e.target.value) || undefined)}
+            placeholder="—"
+          />
+        </div>
+        <div>
+          <Label htmlFor="max_playtime">{t('games.form.max_playtime.label')}</Label>
+          <Input
+            id="max_playtime"
+            type="number"
+            min="0"
+            value={formData.max_playtime ?? ''}
+            onChange={(e) => onChange('max_playtime', parseInt(e.target.value) || undefined)}
+            placeholder="—"
+          />
+        </div>
+      </div>
+
+      {/* Difficulty */}
+      <div>
+        <Label>{t('games.form.difficulty.label')}</Label>
+        <Select value={formData.difficulty} onValueChange={(v) => onChange('difficulty', v)}>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="Beginner">{t('games.form.difficulty.beginner')}</SelectItem>
+            <SelectItem value="Intermediate">{t('games.form.difficulty.intermediate')}</SelectItem>
+            <SelectItem value="Expert">{t('games.form.difficulty.expert')}</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Game Modes */}
       <div className="p-4 rounded-xl border bg-card/50 space-y-3">
         <Label className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">{t('games.form.modes.label')}</Label>
         <div className="grid grid-cols-2 gap-3">
@@ -79,6 +198,111 @@ export default function GameForm({
         </div>
       </div>
 
+      {/* Category / Categories / Mechanics */}
+      <div>
+        <Label htmlFor="category">{t('games.form.category.label')}</Label>
+        <Input
+          id="category"
+          value={formData.category}
+          onChange={(e) => onChange('category', e.target.value)}
+          placeholder={t('games.form.category.placeholder')}
+        />
+      </div>
+      <div>
+        <Label htmlFor="categories">{t('games.form.categories.label')}</Label>
+        <Input
+          id="categories"
+          value={(formData.categories ?? []).join(', ')}
+          onChange={(e) => onChange('categories', e.target.value.split(',').map((s) => s.trim()).filter(Boolean))}
+          placeholder={t('games.form.categories.placeholder')}
+        />
+      </div>
+      <div>
+        <Label htmlFor="mechanics">{t('games.form.mechanics.label')}</Label>
+        <Input
+          id="mechanics"
+          value={(formData.mechanics ?? []).join(', ')}
+          onChange={(e) => onChange('mechanics', e.target.value.split(',').map((s) => s.trim()).filter(Boolean))}
+          placeholder={t('games.form.mechanics.placeholder')}
+        />
+      </div>
+
+      {/* Designer + Publisher */}
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <Label htmlFor="designer">{t('games.form.designer.label')}</Label>
+          <Input
+            id="designer"
+            value={formData.designer}
+            onChange={(e) => onChange('designer', e.target.value)}
+            placeholder={t('games.form.designer.placeholder')}
+          />
+        </div>
+        <div>
+          <Label htmlFor="publisher">{t('games.form.publisher.label')}</Label>
+          <Input
+            id="publisher"
+            value={formData.publisher}
+            onChange={(e) => onChange('publisher', e.target.value)}
+            placeholder={t('games.form.publisher.placeholder')}
+          />
+        </div>
+      </div>
+
+      {/* Year + BGG Rating + Weight */}
+      <div className="grid grid-cols-3 gap-4">
+        <div>
+          <Label htmlFor="year_published">{t('games.form.year.label')}</Label>
+          <Input
+            id="year_published"
+            type="number"
+            min="1800"
+            max="2030"
+            value={formData.year_published}
+            onChange={(e) => onChange('year_published', parseInt(e.target.value) || new Date().getFullYear())}
+            className={errors.year_published ? 'border-destructive' : ''}
+          />
+          {errors.year_published && <p className="text-destructive text-xs mt-1">{errors.year_published}</p>}
+        </div>
+        <div>
+          <Label htmlFor="bgg_rating">{t('games.form.bgg_rating.label')}</Label>
+          <Input
+            id="bgg_rating"
+            type="number"
+            min="0"
+            max="10"
+            step="0.1"
+            value={formData.bgg_rating}
+            onChange={(e) => onChange('bgg_rating', parseFloat(e.target.value) || 0)}
+          />
+        </div>
+        <div>
+          <Label htmlFor="weight">{t('games.form.weight.label')}</Label>
+          <Input
+            id="weight"
+            type="number"
+            min="0"
+            max="5"
+            step="0.1"
+            value={formData.weight}
+            onChange={(e) => onChange('weight', parseFloat(e.target.value) || 0)}
+          />
+        </div>
+      </div>
+
+      {/* Description */}
+      <div>
+        <Label htmlFor="description">{t('games.form.description.label')}</Label>
+        <Textarea
+          id="description"
+          value={formData.description}
+          onChange={(e) => onChange('description', e.target.value)}
+          placeholder={t('games.form.description.placeholder')}
+          rows={3}
+        />
+      </div>
+
+      {/* Has expansion / Is expansion */}
       <div className="flex items-center gap-6">
         <div className="flex items-center space-x-2">
           <Checkbox
@@ -98,6 +322,29 @@ export default function GameForm({
         </div>
       </div>
 
+      {/* Expansions list */}
+      {formData.has_expansion && (
+        <div>
+          <Label>{t('games.form.expansions.label')}</Label>
+          <Textarea
+            value={(formData.expansions ?? []).map(formatExpansion).join(', ')}
+            onChange={(e) => {
+              const parsed = e.target.value.split(',').map((text, idx) => {
+                const t = text.trim();
+                const match = t.match(/^(.+)\((\d{4})\)$/);
+                return match
+                  ? { expansion_id: idx, name: match[1].trim(), year_published: parseInt(match[2]) }
+                  : { expansion_id: idx, name: t, year_published: 0 };
+              }).filter((e) => e.name);
+              onChange('expansions', parsed);
+            }}
+            placeholder={t('games.form.expansions.placeholder')}
+            rows={3}
+          />
+        </div>
+      )}
+
+      {/* Has characters */}
       <div className="space-y-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-2">
@@ -113,7 +360,7 @@ export default function GameForm({
 
         {formData.has_characters && formData.characters?.map((char, idx) => (
           <div key={char.character_key || idx} className="relative p-3 border rounded-lg bg-muted/30">
-            <Button variant="ghost" size="icon" className="absolute top-1 right-1 text-red-500" onClick={() => onRemoveCharacter(idx)}>
+            <Button variant="ghost" size="icon" className="absolute top-1 right-1 text-destructive" onClick={() => onRemoveCharacter(idx)}>
               <Trash size={14} />
             </Button>
             <Input

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,9 @@
   * {
     @apply border-border;
   }
+  body {
+    @apply bg-background text-foreground;
+  }
 }
 
 :root {


### PR DESCRIPTION
## Summary

- **Régressions post-PR #91** : labels invisibles dans les dialogs (`body { @apply bg-background text-foreground }`), `onInteractOutside` perdu sur Add/EditGameDialog, GameForm incomplet (12 champs manquants), clé i18n `games.mode.*` → `games.card.modes.*`
- **AddGameDialog / EditGameDialog** : `DialogDescription` ajoutée, i18n complet via `useLabels()`
- **DESIGN_AUDIT Sprint B** : §25 (amber WCAG AA), §26 (stats text-foreground), §29–§33 GameDetail (tokens shadcn, bottom-nav, kebab mobile, header, cards cliquables)

## Détail

### Régressions PR #91
| Fix | Fichier |
|---|---|
| `body { bg-background text-foreground }` — labels visibles dans Dialog portals | `src/index.css` |
| `onInteractOutside` restauré — dialogs non-dismissables | `AddGameDialog`, `EditGameDialog` |
| GameForm réécrit complet (12 champs manquants) | `dialogs/GameForm.tsx` |
| `GameFormData` étendu (`min/max_playtime`, `categories`, `mechanics`…) | `shared/types/index.d.ts` |
| `games.mode.*` → `games.card.modes.*` | `GamesPageView.tsx` |

### DESIGN_AUDIT Sprint B
| § | Fix |
|---|---|
| §25 | Badge Extension : `text-amber-700 dark:text-amber-400` — WCAG AA conforme |
| §26 | Stats valeurs : `text-foreground` (retrait couleurs décoratifs emerald/blue/purple) |
| §29 | GameOverview : tokens shadcn complets (`bg-card`, `border-border`, `text-foreground`, `text-muted-foreground`) |
| §30 | Bottom-nav GameDetail : bottom-nav inline dupliquée supprimée |
| §31 | Kebab mobile : onglets retirés, `TabsList` unifié mobile+desktop |
| §32 | Header : `bg-background/95 backdrop-blur-sm border-border` |
| §33 | Preview Expansions/Characters : `Card` cliquable + `CaretRight`, bouton « Gérer » retiré |

## Test plan
- [ ] Login → pas de régression
- [ ] Dialogs Add/Edit Game : labels visibles, non-dismissable au clic extérieur, tous les champs présents
- [ ] GamesPageView : badge Extension visible en mode clair, stats en `text-foreground`
- [ ] GameDetailView : header, GameOverview, tabs visibles sur mobile, kebab = gestion seule, cards Expansions/Characters cliquables

🤖 Generated with [Claude Code](https://claude.com/claude-code)